### PR TITLE
Added auto language detection of the title

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -10,6 +10,7 @@ import os
 import glob
 
 import requests
+from langdetect import detect
 
 from . import images
 from . import network
@@ -208,8 +209,15 @@ class Article(object):
         self.set_meta_language(meta_lang)
 
         if self.config.use_meta_language:
-            self.extractor.update_language(self.meta_lang)
-            output_formatter.update_language(self.meta_lang)
+            # If there is no meta language provide, but detect_lang_from_title is true, and there is title text, try to detect language
+            if self.meta_lang == '' and self.config.detect_lang_from_title and self.title != '':
+                detected_lang = detect(self.title)
+                self.extractor.update_language(detected_lang)
+                output_formatter.update_language(detected_lang)
+
+            else:
+                self.extractor.update_language(self.meta_lang)
+                output_formatter.update_language(self.meta_lang)
 
         meta_favicon = self.extractor.get_favicon(self.clean_doc)
         self.set_meta_favicon(meta_favicon)

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -209,15 +209,16 @@ class Article(object):
         self.set_meta_language(meta_lang)
 
         if self.config.use_meta_language:
-            # If there is no meta language provide, but detect_lang_from_title is true, and there is title text, try to detect language
-            if self.meta_lang == '' and self.config.detect_lang_from_title and self.title != '':
-                detected_lang = detect(self.title)
-                self.extractor.update_language(detected_lang)
-                output_formatter.update_language(detected_lang)
+            self.extractor.update_language(self.meta_lang)
+            output_formatter.update_language(self.meta_lang)
 
-            else:
-                self.extractor.update_language(self.meta_lang)
-                output_formatter.update_language(self.meta_lang)
+            # If there is no meta language provide, but detect_lang_from_title is true, and there is title text, try to detect language
+            if not self.meta_lang and self.config.detect_lang_from_title and self.title:
+                detected_lang = detect(self.title)
+                # Make sure the detected language is an available language, or don't use it
+                if detected_lang in get_available_languages():
+                    self.extractor.update_language(detected_lang)
+                    output_formatter.update_language(detected_lang)
 
         meta_favicon = self.extractor.get_favicon(self.clean_doc)
         self.set_meta_favicon(meta_favicon)

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -51,6 +51,9 @@ class Configuration(object):
         # Don't toggle this variable, done internally
         self.use_meta_language = True
 
+        # If use_meta_language is true but cannot be parsed, try detecting lang from title
+        self.detect_lang_from_title = True
+
         # You may keep the html of just the main article body
         self.keep_article_html = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ feedfinder2>=0.0.4
 jieba3k>=0.35.1
 python-dateutil>=2.5.3
 tinysegmenter==0.3
+langdetect>=1.0.7


### PR DESCRIPTION
Tries to auto-detect the language from the title if you were going to try to use the meta data language but it couldn't find one, there is title text, and you didn't disable this auto-detect feature.